### PR TITLE
add rule to .eslint to prevent merge conflicts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "no-unused-vars": "warn",
     "quotes": [2, "single"],
     "semi": ["warn", "always"],
-    "no-console": ["warn", {"allow": ["log", "warn", "error"]}]
+    "no-console": ["warn", {"allow": ["log", "warn", "error"]}],
+    "no-trailing-spaces": "error"
   }
 }


### PR DESCRIPTION
Leaving trailing whitespaces can lead to merge conflicts if they later get deleted by one person, but left in by another.